### PR TITLE
Update build-debian-11.sh

### DIFF
--- a/build-debian-11.sh
+++ b/build-debian-11.sh
@@ -7,7 +7,7 @@ rm packages-microsoft-prod.deb
 
 # install dev-dependencies
 sudo apt-get update; \
-  sudo apt-get -y install dotnet-sdk-6.0 git cmake build-essential libssl-dev pkg-config libboost-all-dev libsodium-dev libzmq5
+  sudo apt-get -y install dotnet-sdk-6.0 git cmake build-essential libssl-dev pkg-config libboost-all-dev libsodium-dev libzmq5-dev
 
 (cd src/Miningcore && \
 BUILDIR=${1:-../../build} && \


### PR DESCRIPTION
At least on Debian, the regular libzmq5 package is not enough - you need a "dev" version.