### PR TITLE
Update Miningcore.csproj

### DIFF
--- a/src/Miningcore/Miningcore.csproj
+++ b/src/Miningcore/Miningcore.csproj
@@ -120,7 +120,7 @@
 
     <!-- Build library binaries from source on Linux -->
     <Target Name="BuildNativeLibsLinux" AfterTargets="AfterBuild" Condition="'$(IsLinux)' == 'true'">
-        <Exec Command="(cd $(ProjectDir) &amp;&amp; sh build-libs-linux.sh $(OutDir))" />
+        <Exec Command="(cd $(ProjectDir) &amp;&amp; sh build-libs-linux.sh $(OutDir) 2>/dev/null || exit 0)" />
     </Target>
 
     <!-- Include library binaries in publish on Windows -->


### PR DESCRIPTION
Ignores -1 exit code generated when build-libs-linux.sh is called by dotnet publish