### PR TITLE
fix: consistantly set eth address to lowercase

### DIFF
--- a/src/Miningcore/Api/Controllers/PoolApiController.cs
+++ b/src/Miningcore/Api/Controllers/PoolApiController.cs
@@ -568,6 +568,9 @@ public class PoolApiController : ApiControllerBase
         if(string.IsNullOrEmpty(address))
             throw new ApiException("Invalid or missing miner address", HttpStatusCode.NotFound);
 
+        if(pool.Template.Family == CoinFamily.Ethereum)
+            address = address.ToLower();
+
         var result = await cf.Run(con=> minerRepo.GetSettingsAsync(con, null, pool.Id, address));
 
         if(result == null)
@@ -584,6 +587,9 @@ public class PoolApiController : ApiControllerBase
 
         if(string.IsNullOrEmpty(address))
             throw new ApiException("Invalid or missing miner address", HttpStatusCode.NotFound);
+
+        if(pool.Template.Family == CoinFamily.Ethereum)
+            address = address.ToLower();
 
         if(request?.Settings == null)
             throw new ApiException("Invalid or missing settings", HttpStatusCode.BadRequest);


### PR DESCRIPTION
Makes the settings api endpoint case-insensitive for ethereum chains.