### PR TITLE
fixed grep issues with check cpu logic

### DIFF
--- a/src/Native/check_cpu.sh
+++ b/src/Native/check_cpu.sh
@@ -20,17 +20,17 @@ check_mac() {
 
 check_linux() {
     case "$1" in
-      aes) grep aes /proc/cpuinfo >/dev/null;;
-      avx) grep avx /proc/cpuinfo >/dev/null;;
-      avx2) grep avx2 /proc/cpuinfo >/dev/null;;
+      aes) grep -w 'aes' /proc/cpuinfo >/dev/null;;
+      avx) grep -w 'avx' /proc/cpuinfo >/dev/null;;
+      avx2) grep -w 'avx2' /proc/cpuinfo >/dev/null;;
       amd) grep -i amd /proc/cpuinfo >/dev/null;;
       amdnew) grep -i amd /proc/cpuinfo >/dev/null && test `awk '/cpu family/ && $NF~/^[0-9]*$/ {print $NF}' /proc/cpuinfo | head -n1` -ge 23 >/dev/null;;
       intel) grep -i intel /proc/cpuinfo >/dev/null;;
-      sse2) grep sse2 /proc/cpuinfo >/dev/null;;
-      sse3) grep sse3 /proc/cpuinfo >/dev/null;;
-      ssse3) grep ssse3 /proc/cpuinfo >/dev/null;;
-      avx512f) grep avx512f /proc/cpuinfo >/dev/null;;
-      xop) grep xop /proc/cpuinfo >/dev/null;;
+      sse2) grep -w 'sse2' /proc/cpuinfo >/dev/null;;
+      sse3) grep -w 'sse3' /proc/cpuinfo >/dev/null;;
+      ssse3) grep -w 'ssse3' /proc/cpuinfo >/dev/null;;
+      avx512f) grep -w 'avx512f' /proc/cpuinfo >/dev/null;;
+      xop) grep -w 'xop' /proc/cpuinfo >/dev/null;;
       *) echo "UNRECOGNISED CHECK $QUERY"; exit 1; ;;
     esac
 }


### PR DESCRIPTION
Fixed grep issue to solve issues where a Xeon processor can support ssse3 but not sse3.