### PR TITLE
feat: improve gpdr compliance by censoring IPs in the logs

### DIFF
--- a/src/Miningcore.Tests/Benchmarks/Stratum/StratumConnectionBenchmarks.cs
+++ b/src/Miningcore.Tests/Benchmarks/Stratum/StratumConnectionBenchmarks.cs
@@ -39,7 +39,7 @@ public class StratumConnectionBenchmarks : TestBase
         clock = ModuleInitializer.Container.Resolve<IMasterClock>();
         logger = new NullLogger(LogManager.LogFactory);
 
-        connection = new(logger, rmsm, clock, ConnectionId);
+        connection = new(logger, rmsm, clock, ConnectionId, false);
         wrapper = new(connection);
     }
 

--- a/src/Miningcore.Tests/Stratum/StratumConnectionTests.cs
+++ b/src/Miningcore.Tests/Stratum/StratumConnectionTests.cs
@@ -34,7 +34,7 @@ public class StratumConnectionTests : TestBase
     [Fact]
     public async Task ProcessRequest_Handle_Valid_Request()
     {
-        var connection = new StratumConnection(logger, rmsm, clock, ConnectionId);
+        var connection = new StratumConnection(logger, rmsm, clock, ConnectionId, false);
         var wrapper = new PrivateObject(connection);
 
         Task handler(StratumConnection con, JsonRpcRequest request, CancellationToken ct)
@@ -61,7 +61,7 @@ public class StratumConnectionTests : TestBase
     {
         const string invalidRequestString = "foo bar\\n";
 
-        var connection = new StratumConnection(logger, rmsm, clock, ConnectionId);
+        var connection = new StratumConnection(logger, rmsm, clock, ConnectionId, false);
         var wrapper = new PrivateObject(connection);
         var callCount = 0;
 
@@ -82,7 +82,7 @@ public class StratumConnectionTests : TestBase
     [Fact]
     public async Task ProcessRequest_Honor_CancellationToken()
     {
-        var connection = new StratumConnection(logger, rmsm, clock, ConnectionId);
+        var connection = new StratumConnection(logger, rmsm, clock, ConnectionId, false);
         var wrapper = new PrivateObject(connection);
         var callCount = 0;
 

--- a/src/Miningcore/Api/Middlewares/IPAccessWhitelistMiddleware.cs
+++ b/src/Miningcore/Api/Middlewares/IPAccessWhitelistMiddleware.cs
@@ -1,32 +1,35 @@
 using Microsoft.AspNetCore.Http;
 using NLog;
 using System.Net;
+using Miningcore.Configuration;
+using Miningcore.Extensions;
 
 namespace Miningcore.Api.Middlewares;
 
 public class IPAccessWhitelistMiddleware
 {
-    public IPAccessWhitelistMiddleware(RequestDelegate next, string[] locations, IPAddress[] whitelist)
+    public IPAccessWhitelistMiddleware(RequestDelegate next, string[] locations, IPAddress[] whitelist, bool gpdrCompliantLogging)
     {
         this.whitelist = whitelist;
         this.next = next;
         this.locations = locations;
+        this.gpdrCompliantLogging = gpdrCompliantLogging;
     }
 
     private readonly RequestDelegate next;
     private readonly ILogger logger = LogManager.GetCurrentClassLogger();
     private readonly IPAddress[] whitelist;
     private readonly string[] locations;
+    private readonly bool gpdrCompliantLogging;
 
     public async Task Invoke(HttpContext context)
     {
         if(locations.Any(x => context.Request.Path.Value.StartsWith(x)))
         {
             var remoteAddress = context.Connection.RemoteIpAddress;
-
             if(!whitelist.Any(x => x.Equals(remoteAddress)))
             {
-                logger.Info(() => $"Unauthorized request attempt to {context.Request.Path.Value} from {remoteAddress}");
+                logger.Info(() => $"Unauthorized request attempt to {context.Request.Path.Value} from {remoteAddress.CensorOrReturn(gpdrCompliantLogging)}");
 
                 context.Response.StatusCode = (int) HttpStatusCode.Forbidden;
                 await context.Response.WriteAsync("You are not in my access list. Good Bye.\n");

--- a/src/Miningcore/Configuration/ClusterConfig.cs
+++ b/src/Miningcore/Configuration/ClusterConfig.cs
@@ -531,6 +531,7 @@ public partial class ClusterLoggingConfig
     public string ApiLogFile { get; set; }
     public bool PerPoolLogFile { get; set; }
     public string LogBaseDirectory { get; set; }
+    public bool GPDRCompliant { get; set; }
 }
 
 public partial class NetworkEndpointConfig

--- a/src/Miningcore/Extensions/IpAddressExtensions.cs
+++ b/src/Miningcore/Extensions/IpAddressExtensions.cs
@@ -24,4 +24,35 @@ public static class IpAddressExtensions
 
         return false;
     }
+
+    public static IPAddress CensorOrReturn(this IPAddress address, bool censor)
+    {
+        Contract.RequiresNonNull(address);
+
+        if(!censor)
+            return address;
+
+        if(address.IsIPv4MappedToIPv6)
+            address = address.MapToIPv4();
+
+        var ipBytes = address.GetAddressBytes();
+
+        if(ipBytes.Length == 4)
+        {
+            // IPv4
+            // keep the first and last part
+            ipBytes[2] = 0;
+            ipBytes[3] = 0;
+        }
+
+        else if(ipBytes.Length == 16)
+        {
+            // IPv6
+            // keep the first 2 and last 2 parts
+            for(var i = 4; i < 12; i++)
+                ipBytes[i] = 0;
+        }
+
+        return new IPAddress(ipBytes);
+    }
 }

--- a/src/Miningcore/Program.cs
+++ b/src/Miningcore/Program.cs
@@ -945,7 +945,7 @@ public class Program : BackgroundService
 
             logger.Info(() => $"API Access to {string.Join(",", locations)} restricted to {string.Join(",", ipList.Select(x => x.ToString()))}");
 
-            app.UseMiddleware<IPAccessWhitelistMiddleware>(locations, ipList.ToArray());
+            app.UseMiddleware<IPAccessWhitelistMiddleware>(locations, ipList.ToArray(), clusterConfig.Logging.GPDRCompliant);
         }
     }
 

--- a/src/Miningcore/Stratum/StratumServer.cs
+++ b/src/Miningcore/Stratum/StratumServer.cs
@@ -154,9 +154,9 @@ public abstract class StratumServer
                 return;
 
             // init connection
-            var connection = new StratumConnection(logger, rmsm, clock, CorrelationIdGenerator.GetNextId());
+            var connection = new StratumConnection(logger, rmsm, clock, CorrelationIdGenerator.GetNextId(), clusterConfig.Logging.GPDRCompliant);
 
-            logger.Info(() => $"[{connection.ConnectionId}] Accepting connection from {remoteEndpoint.Address}:{remoteEndpoint.Port} ...");
+            logger.Info(() => $"[{connection.ConnectionId}] Accepting connection from {remoteEndpoint.Address.CensorOrReturn(clusterConfig.Logging.GPDRCompliant)}:{remoteEndpoint.Port} ...");
 
             RegisterConnection(connection);
             OnConnect(connection, port.IPEndPoint);


### PR DESCRIPTION
This adds an option to enable GPDR compliant logging by censoring IPs. 

`192.168.1.1` will be logged as `192.0.0.1`
`fe80:0001:0002:0003:0202:b3ff:fe1e:8329` will be logged as `fe80:1::fe1e:8329`

This keeps the IP address distinguishable to a certain degree without logging them completely. 

GPDR compliant logging is configurable in the logging config and disabled by default. 

closes #1205 