### PR TITLE
fix: ethereum payout bug

### DIFF
--- a/src/Miningcore/Blockchain/Ethereum/Configuration/EthereumPoolPaymentProcessingConfigExtra.cs
+++ b/src/Miningcore/Blockchain/Ethereum/Configuration/EthereumPoolPaymentProcessingConfigExtra.cs
@@ -21,4 +21,9 @@ public class EthereumPoolPaymentProcessingConfigExtra
     /// maximum amount you’re willing to pay
     /// </summary>
     public ulong MaxFeePerGas { get; set; }
+
+    /// <summary>
+    /// Search offset to start looking for uncles
+    /// </summary>
+    public uint BlockSearchOffset { get; set; } = 50;
 }

--- a/src/Miningcore/Blockchain/Ethereum/EthereumConstants.cs
+++ b/src/Miningcore/Blockchain/Ethereum/EthereumConstants.cs
@@ -17,6 +17,7 @@ public class EthereumConstants
     public const string EthereumStratumVersion = "EthereumStratum/1.0.0";
     public const decimal StaticTransactionFeeReserve = 0.0025m; // in ETH
     public const string BlockTypeUncle = "uncle";
+    public const string BlockTypeBlock = "block";
 
 #if !DEBUG
     public const int MinPayoutPeerCount = 1;

--- a/src/Miningcore/Payments/PayoutManager.cs
+++ b/src/Miningcore/Payments/PayoutManager.cs
@@ -62,11 +62,11 @@ public class PayoutManager : BackgroundService
     private readonly ClusterConfig clusterConfig;
     private readonly CompositeDisposable disposables = new();
 
-    #if !DEBUG
+#if !DEBUG
     private static readonly TimeSpan initialRunDelay = TimeSpan.FromMinutes(1);
-    #else
+#else
     private static readonly TimeSpan initialRunDelay = TimeSpan.FromSeconds(15);
-    #endif
+#endif
 
     private void AttachPool(IMiningPool pool)
     {

--- a/src/Miningcore/Persistence/Postgres/Repositories/BlockRepository.cs
+++ b/src/Miningcore/Persistence/Postgres/Repositories/BlockRepository.cs
@@ -51,12 +51,12 @@ public class BlockRepository : IBlockRepository
             ORDER BY created DESC OFFSET @offset FETCH NEXT @pageSize ROWS ONLY";
 
         return (await con.QueryAsync<Entities.Block>(new CommandDefinition(query, new
-            {
-                poolId,
-                status = status.Select(x => x.ToString().ToLower()).ToArray(),
-                offset = page * pageSize,
-                pageSize
-            }, cancellationToken: ct)))
+        {
+            poolId,
+            status = status.Select(x => x.ToString().ToLower()).ToArray(),
+            offset = page * pageSize,
+            pageSize
+        }, cancellationToken: ct)))
             .Select(mapper.Map<Block>)
             .ToArray();
     }
@@ -67,11 +67,11 @@ public class BlockRepository : IBlockRepository
             ORDER BY created DESC OFFSET @offset FETCH NEXT @pageSize ROWS ONLY";
 
         return (await con.QueryAsync<Entities.Block>(new CommandDefinition(query, new
-            {
-                status = status.Select(x => x.ToString().ToLower()).ToArray(),
-                offset = page * pageSize,
-                pageSize
-            }, cancellationToken: ct)))
+        {
+            status = status.Select(x => x.ToString().ToLower()).ToArray(),
+            offset = page * pageSize,
+            pageSize
+        }, cancellationToken: ct)))
             .Select(mapper.Map<Block>)
             .ToArray();
     }
@@ -91,11 +91,11 @@ public class BlockRepository : IBlockRepository
             ORDER BY created DESC FETCH NEXT 1 ROWS ONLY";
 
         return (await con.QueryAsync<Entities.Block>(query, new
-            {
-                poolId,
-                before,
-                status = status.Select(x => x.ToString().ToLower()).ToArray()
-            }))
+        {
+            poolId,
+            before,
+            status = status.Select(x => x.ToString().ToLower()).ToArray()
+        }))
             .Select(mapper.Map<Block>)
             .FirstOrDefault();
     }
@@ -112,5 +112,14 @@ public class BlockRepository : IBlockRepository
         const string query = @"SELECT created FROM blocks WHERE poolid = @poolId ORDER BY created DESC LIMIT 1";
 
         return con.ExecuteScalarAsync<DateTime?>(query, new { poolId });
+    }
+
+    public async Task<Block> GetBlockByHeightAsync(IDbConnection con, string poolId, long height)
+    {
+        const string query = @"SELECT * FROM blocks WHERE poolid = @poolId AND blockheight = @height";
+
+        var entity = await con.QuerySingleOrDefaultAsync<Entities.Block>(new CommandDefinition(query, new { poolId, height }));
+
+        return entity == null ? null : mapper.Map<Block>(entity);
     }
 }

--- a/src/Miningcore/Persistence/Repositories/IBlockRepository.cs
+++ b/src/Miningcore/Persistence/Repositories/IBlockRepository.cs
@@ -15,4 +15,5 @@ public interface IBlockRepository
     Task<Block> GetBlockBeforeAsync(IDbConnection con, string poolId, BlockStatus[] status, DateTime before);
     Task<uint> GetPoolBlockCountAsync(IDbConnection con, string poolId, CancellationToken ct);
     Task<DateTime?> GetLastPoolBlockTimeAsync(IDbConnection con, string poolId);
+    Task<Block> GetBlockByHeightAsync(IDbConnection con, string poolId, long height);
 }


### PR DESCRIPTION
This improves how miningcore classifies uncles on ethereum and prevents miningcore from trying to insert a block twice. 

This PR also adds a new config option to fine tune the search range for uncles. I noticed that 50 is to low on certain ethereum type blockchains. By increasing the value to 75 or 100, miningcore could confirm a lot of blocks which were previously marked as orphans. 

closes #1080 