### PR TITLE
fix  uncle blokcs are orphaned

### DIFF
--- a/src/Miningcore/Blockchain/Ethereum/EthereumPayoutHandler.cs
+++ b/src/Miningcore/Blockchain/Ethereum/EthereumPayoutHandler.cs
@@ -158,6 +158,7 @@ public class EthereumPayoutHandler : PayoutHandlerBase,
 
                 // execute batch
                 var blockInfo2s = await FetchBlocks(blockCache, ct, range.ToArray());
+                var matchUncle = false;
 
                 foreach(var blockInfo2 in blockInfo2s)
                 {
@@ -212,13 +213,19 @@ public class EthereumPayoutHandler : PayoutHandlerBase,
                                 messageBus.NotifyBlockUnlocked(poolConfig.Id, block, coin);
                             }
 
-                            else
+                            else {
+                                matchUncle = false;
                                 logger.Info(() => $"[{LogCategory}] Got immature matching uncle for block {blockInfo2.Height.Value}. Will try again.");
+                            }
 
                             break;
                         }
                     }
                 }
+                
+                if (matchUncle)
+                    continue;
+                
 
                 if(block.Status == BlockStatus.Pending && block.ConfirmationProgress > 0.75)
                 {


### PR DESCRIPTION
From the perspective of the integrity of the program code, conitnue is missing when confirming the uncle block, which leads to the wrong entry of if block.ConfirmationProgress > 0.75 , cause uncle blocks to become orphan blocks